### PR TITLE
Fix PHPCS issue with an unused variable in the setup file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Changelog formatting (http://semver.org/):
 
 ### Build Tooling
 
+- PHP coding standards linter updates: PHP Codesniffer, WPCS coding standards, and PHPCS Variable Analysis. (bb34e38)
+- Update WordPress Stylelint config plugin to 17.0.0. (e4fabc4)
+- Update Webpack build plugins Copy Webpack Plugin and Source Map Loader. (7ad650a)
+- Update ESLint and associated plugins, WP ESLint plugin and WP Prettier. (15c37e5)
 - Update non-breaking NPM dependencies (6d153e1):
     - WordPress Babel preset: update to latest version.
     - WordPress dependency extraction Webpack plugin: update to latest version.

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -154,7 +154,7 @@ class Setup {
 		 * Retrieves the block registration file for each dynamic block.
 		 */
 		$blocks_dir = dirname( __DIR__ ) . '/build/blocks/';
-		foreach ( $this->blocks as $name => $file ) {
+		foreach ( $this->blocks as $file ) {
 			if ( 0 === $file || ! file_exists( $blocks_dir . $file ) ) {
 				continue;
 			}


### PR DESCRIPTION
## Description

Fix PHPCS issue with an unused variable in the setup file.

## How has this been tested?

The blocks loaded by the modified function are still loading as expected.

## Types of changes

Code quality fix.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
