### PR TITLE
Fix Copy Webpack Plugin patterns syntax for v6.0 changes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,8 @@
  * External dependencies
  */
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
-const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
-const { escapeRegExp } = require( 'lodash' );
-const { resolve, sep } = require( 'path' );
+const CopyPlugin = require( 'copy-webpack-plugin' );
+const { resolve, basename, dirname } = require( 'path' );
 
 /**
  * WordPress dependencies
@@ -60,27 +59,26 @@ const config = {
 		// WP_BUNDLE_ANALYZER global variable enables utility that represents
 		// bundle content as a convenient interactive zoomable treemap.
 		process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
-		new CopyWebpackPlugin( [
-			{
-				from: './src/blocks/**/index.php',
-				test: new RegExp(
-					`([\\w-]+)${ escapeRegExp( sep ) }index\\.php$`
-				),
-				to: 'blocks/[1].php',
-			},
-		] ),
-		new CopyWebpackPlugin( [
-			{
-				from: './src/icons/**/*',
-				to: 'icons/[name].[ext]',
-			},
-		] ),
-		new CopyWebpackPlugin( [
-			{
-				from: './node_modules/mark.js/dist/mark.min.js',
-				to: 'lib/[name].js',
-			},
-		] ),
+		new CopyPlugin( {
+			patterns: [
+				{
+					from: './src/blocks/**/index.php',
+					to: 'blocks/',
+					transformPath( targetPath ) {
+						const dir = basename( dirname( targetPath ) );
+						return `blocks/${ dir }.php`;
+					},
+				},
+				{
+					from: './src/icons/**/*',
+					to: 'icons/[name].[ext]',
+				},
+				{
+					from: './node_modules/mark.js/dist/mark.min.js',
+					to: 'lib/[name].js',
+				},
+			],
+		} ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	].filter( Boolean ),
 	stats: {


### PR DESCRIPTION
## Description

Copy Webpack Plugin changed their configuration syntax to take an object and replaced `test` with `transormPath`. Update the syntax to use an object and change the copy-to path modification script.

## How has this been tested?

Build processes run as expected - errors resolved.

## Types of changes

Fix Webpack configuration to align with Copy Webpack changes.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.